### PR TITLE
conditional eeprom support

### DIFF
--- a/Timezone.cpp
+++ b/Timezone.cpp
@@ -9,8 +9,11 @@
  * San Francisco, California, 94105, USA.                               *
  *----------------------------------------------------------------------*/
 
-#include <avr/eeprom.h>
 #include "Timezone.h"
+
+#ifdef __AVR__
+	#include <avr/eeprom.h>
+#endif
 
 /*----------------------------------------------------------------------*
  * Create a Timezone object from the given time change rules.           *
@@ -21,6 +24,7 @@ Timezone::Timezone(TimeChangeRule dstStart, TimeChangeRule stdStart)
     _std = stdStart;
 }
 
+#ifdef __AVR__
 /*----------------------------------------------------------------------*
  * Create a Timezone object from time change rules stored in EEPROM     *
  * at the given address.                                                *
@@ -29,6 +33,7 @@ Timezone::Timezone(int address)
 {
     readRules(address);
 }
+#endif
 
 /*----------------------------------------------------------------------*
  * Convert the given UTC time to local time, standard or                *
@@ -176,6 +181,7 @@ time_t Timezone::toTime_t(TimeChangeRule r, int yr)
     return t;
 }
 
+#ifdef __AVR__
 /*----------------------------------------------------------------------*
  * Read the daylight and standard time rules from EEPROM at				*
  * the given address.                                                   *
@@ -197,3 +203,5 @@ void Timezone::writeRules(int address)
     address += sizeof(_dst);
     eeprom_write_block((void *) &_std, (void *) address, sizeof(_std));
 }
+
+#endif


### PR DESCRIPTION
When using the Arduino IDE to compile for some of the newer boards,
such as those based on the ESP8266, the library won’t compile as the
IDE knows EEPROM isn’t supported. My change adds conditional compiles
that take out the EEPROM-dependent code.
